### PR TITLE
Fix for the erratic behavior of ROOT "Form" service

### DIFF
--- a/QnCorrections/QnCorrectionsInputGainEqualization.cxx
+++ b/QnCorrections/QnCorrectionsInputGainEqualization.cxx
@@ -127,7 +127,7 @@ void QnCorrectionsInputGainEqualization::CreateSupportDataStructures() {
 /// \return kTRUE if everything went OK
 Bool_t QnCorrectionsInputGainEqualization::CreateSupportHistograms(TList *list) {
 
-  TString histoNameAndTitle = Form("%s %s",
+  TString histoNameAndTitle = TString::Format("%s %s",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
 
@@ -150,19 +150,19 @@ QnCorrectionsDetectorConfigurationChannels *ownerConfiguration =
 /// \param list list where the histograms should be incorporated for its persistence
 /// \return kTRUE if everything went OK
 Bool_t QnCorrectionsInputGainEqualization::CreateQAHistograms(TList *list) {
-  TString beforeName = Form("%s %s",
+  TString beforeName = TString::Format("%s %s",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
   beforeName += "Before";
-  TString beforeTitle = Form("%s %s",
+  TString beforeTitle = TString::Format("%s %s",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
   beforeTitle += " before gain equalization";
-  TString afterName = Form("%s %s",
+  TString afterName = TString::Format("%s %s",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
   afterName += "After";
-  TString afterTitle = Form("%s %s",
+  TString afterTitle = TString::Format("%s %s",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
   afterTitle += " after gain equalization";
@@ -192,8 +192,8 @@ Bool_t QnCorrectionsInputGainEqualization::CreateNveQAHistograms(TList *list) {
   QnCorrectionsDetectorConfigurationChannels *ownerConfiguration =
       static_cast<QnCorrectionsDetectorConfigurationChannels *>(fDetectorConfiguration);
   fQANotValidatedBin = new QnCorrectionsHistogramChannelizedSparse(
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
       ownerConfiguration->GetEventClassVariablesSet(),
       ownerConfiguration->GetNoOfChannels());
   fQANotValidatedBin->CreateChannelizedHistogram(list, ownerConfiguration->GetUsedChannelsMask());

--- a/QnCorrections/QnCorrectionsProfile3DCorrelations.cxx
+++ b/QnCorrections/QnCorrectionsProfile3DCorrelations.cxx
@@ -197,8 +197,8 @@ Bool_t QnCorrectionsProfile3DCorrelations::CreateCorrelationComponentsProfileHis
         currentHarmonic++;
       }
       /* let's build the histograms names and titles */
-      TString BaseName = Form("%s %sx%s", GetName(), combNames[ixComb], combNames[(ixComb+1)%CORRELATIONSNOOFQNVECTORS]);
-      TString BaseTitle = Form("%s %sx%s", GetTitle(), combNames[ixComb], combNames[(ixComb+1)%CORRELATIONSNOOFQNVECTORS]);
+      TString BaseName = TString::Format("%s %sx%s", GetName(), combNames[ixComb], combNames[(ixComb+1)%CORRELATIONSNOOFQNVECTORS]);
+      TString BaseTitle = TString::Format("%s %sx%s", GetTitle(), combNames[ixComb], combNames[(ixComb+1)%CORRELATIONSNOOFQNVECTORS]);
       TString histoXXName = BaseName; histoXXName += szXXCorrelationComponentSuffix;
       TString histoXYName = BaseName; histoXYName += szXYCorrelationComponentSuffix;
       TString histoYXName = BaseName; histoYXName += szYXCorrelationComponentSuffix;
@@ -208,17 +208,17 @@ Bool_t QnCorrectionsProfile3DCorrelations::CreateCorrelationComponentsProfileHis
       TString histoYXTitle = BaseTitle; histoYXTitle += szYXCorrelationComponentSuffix;
       TString histoYYTitle = BaseTitle; histoYYTitle += szYYCorrelationComponentSuffix;
 
-      fXXValues[ixComb][currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoXXName, currentHarmonic * fHarmonicMultiplier),
-          Form("%s h%d", (const char *) histoXXTitle, currentHarmonic),
+      fXXValues[ixComb][currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoXXName, currentHarmonic * fHarmonicMultiplier).Data(),
+          TString::Format("%s h%d", (const char *) histoXXTitle, currentHarmonic).Data(),
           nVariables,nbins,minvals,maxvals);
-      fXYValues[ixComb][currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoXYName, currentHarmonic * fHarmonicMultiplier),
-          Form("%s h%d", (const char *) histoXYTitle, currentHarmonic),
+      fXYValues[ixComb][currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoXYName, currentHarmonic * fHarmonicMultiplier).Data(),
+          TString::Format("%s h%d", (const char *) histoXYTitle, currentHarmonic).Data(),
           nVariables,nbins,minvals,maxvals);
-      fYXValues[ixComb][currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoYXName, currentHarmonic * fHarmonicMultiplier),
-          Form("%s h%d", (const char *) histoYXTitle, currentHarmonic),
+      fYXValues[ixComb][currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoYXName, currentHarmonic * fHarmonicMultiplier).Data(),
+          TString::Format("%s h%d", (const char *) histoYXTitle, currentHarmonic).Data(),
           nVariables,nbins,minvals,maxvals);
-      fYYValues[ixComb][currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoYYName, currentHarmonic * fHarmonicMultiplier),
-          Form("%s h%d", (const char *) histoYYTitle, currentHarmonic),
+      fYYValues[ixComb][currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoYYName, currentHarmonic * fHarmonicMultiplier).Data(),
+          TString::Format("%s h%d", (const char *) histoYYTitle, currentHarmonic).Data(),
           nVariables,nbins,minvals,maxvals);
 
       /* now let's set the proper binning and label on each axis */

--- a/QnCorrections/QnCorrectionsProfileComponents.cxx
+++ b/QnCorrections/QnCorrectionsProfileComponents.cxx
@@ -151,11 +151,11 @@ Bool_t QnCorrectionsProfileComponents::CreateComponentsProfileHistograms(TList *
     else {
       currentHarmonic++;
     }
-    fXValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoXName, currentHarmonic),
-        Form("%s h%d", (const char *) histoXTitle, currentHarmonic),
+    fXValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoXName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoXTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
-    fYValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoYName, currentHarmonic),
-        Form("%s h%d", (const char *) histoYTitle, currentHarmonic),
+    fYValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoYName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoYTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
 
     /* now let's set the proper binning and label on each axis */
@@ -246,8 +246,8 @@ Bool_t QnCorrectionsProfileComponents::AttachHistograms(TList *histogramList) {
     for (Int_t i = 0; i < nMaxHarmonicNumberSupported; i++) {
       currentHarmonic++;
 
-      fXValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoXName, currentHarmonic));
-      fYValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoYName, currentHarmonic));
+      fXValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoXName, currentHarmonic).Data());
+      fYValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoYName, currentHarmonic).Data());
 
       /* and update the fully filled condition whether applicable */
       if ((fXValues[currentHarmonic]  != NULL) && (fYValues[currentHarmonic] != NULL))

--- a/QnCorrections/QnCorrectionsProfileCorrelationComponentsHarmonics.cxx
+++ b/QnCorrections/QnCorrectionsProfileCorrelationComponentsHarmonics.cxx
@@ -176,17 +176,17 @@ Bool_t QnCorrectionsProfileCorrelationComponentsHarmonics::CreateCorrelationComp
     else {
       currentHarmonic++;
     }
-    fXXValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoXXName, currentHarmonic),
-        Form("%s h%d", (const char *) histoXXTitle, currentHarmonic),
+    fXXValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoXXName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoXXTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
-    fXYValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoXYName, currentHarmonic),
-        Form("%s h%d", (const char *) histoXYTitle, currentHarmonic),
+    fXYValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoXYName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoXYTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
-    fYXValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoYXName, currentHarmonic),
-        Form("%s h%d", (const char *) histoYXTitle, currentHarmonic),
+    fYXValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoYXName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoYXTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
-    fYYValues[currentHarmonic] = new THnF(Form("%s_h%d", (const char *) histoYYName, currentHarmonic),
-        Form("%s h%d", (const char *) histoYYTitle, currentHarmonic),
+    fYYValues[currentHarmonic] = new THnF(TString::Format("%s_h%d", (const char *) histoYYName, currentHarmonic).Data(),
+        TString::Format("%s h%d", (const char *) histoYYTitle, currentHarmonic).Data(),
         nVariables,nbins,minvals,maxvals);
 
     /* now let's set the proper binning and label on each axis */
@@ -305,10 +305,10 @@ Bool_t QnCorrectionsProfileCorrelationComponentsHarmonics::AttachHistograms(TLis
     for (Int_t i = 0; i < nMaxHarmonicNumberSupported; i++) {
       currentHarmonic++;
 
-      fXXValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoXXName, currentHarmonic));
-      fXYValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoXYName, currentHarmonic));
-      fYXValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoYXName, currentHarmonic));
-      fYYValues[currentHarmonic] = (THnF *) histogramList->FindObject(Form("%s_h%d", (const char *) histoYYName, currentHarmonic));
+      fXXValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoXXName, currentHarmonic).Data());
+      fXYValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoXYName, currentHarmonic).Data());
+      fYXValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoYXName, currentHarmonic).Data());
+      fYYValues[currentHarmonic] = (THnF *) histogramList->FindObject(TString::Format("%s_h%d", (const char *) histoYYName, currentHarmonic).Data());
 
       /* and update the fully filled condition whether applicable */
       if ((fXXValues[currentHarmonic]  != NULL) && (fXYValues[currentHarmonic] != NULL)

--- a/QnCorrections/QnCorrectionsQnVectorAlignment.cxx
+++ b/QnCorrections/QnCorrectionsQnVectorAlignment.cxx
@@ -84,9 +84,9 @@ QnCorrectionsQnVectorAlignment::~QnCorrectionsQnVectorAlignment() {
 /// The detector configuration name is stored for further use.
 /// \param name the name of the reference detector configuration
 void QnCorrectionsQnVectorAlignment::SetReferenceConfigurationForAlignment(const char *name) {
-  QnCorrectionsInfo(Form("Reference name: %s, attached to detector configuration: %s",
+  QnCorrectionsInfo(TString::Format("Reference name: %s, attached to detector configuration: %s",
       name,
-      ((fDetectorConfiguration != NULL) ? "yes" : "no")));
+      ((fDetectorConfiguration != NULL) ? "yes" : "no")).Data());
 
   fDetectorConfigurationForAlignmentName = name;
 
@@ -97,7 +97,7 @@ void QnCorrectionsQnVectorAlignment::SetReferenceConfigurationForAlignment(const
 /// Informs when the detector configuration has been attached to the framework manager
 /// Basically this allows interaction between the different framework sections at configuration time
 void QnCorrectionsQnVectorAlignment::AttachedToFrameworkManager() {
-  QnCorrectionsInfo(Form("Attached! reference for alignment: %s", fDetectorConfigurationForAlignmentName.Data()));
+  QnCorrectionsInfo(TString::Format("Attached! reference for alignment: %s", fDetectorConfigurationForAlignmentName.Data()).Data());
 
 }
 
@@ -147,7 +147,7 @@ void QnCorrectionsQnVectorAlignment::CreateSupportDataStructures() {
 /// \return kTRUE if everything went OK
 Bool_t QnCorrectionsQnVectorAlignment::CreateSupportHistograms(TList *list) {
 
-  TString histoNameAndTitle = Form("%s %s#times%s ",
+  TString histoNameAndTitle = TString::Format("%s %s#times%s ",
       szSupportHistogramName,
       fDetectorConfiguration->GetName(),
       fDetectorConfigurationForAlignment->GetName());
@@ -183,8 +183,8 @@ Bool_t QnCorrectionsQnVectorAlignment::AttachInput(TList *list) {
 Bool_t QnCorrectionsQnVectorAlignment::CreateQAHistograms(TList *list) {
 
   fQAQnAverageHistogram = new QnCorrectionsProfileComponents(
-      Form("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()),
-      Form("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()),
+      TString::Format("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
+      TString::Format("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
       fDetectorConfiguration->GetEventClassVariablesSet());
 
   /* get information about the configured harmonics to pass it for histogram creation */
@@ -204,8 +204,8 @@ Bool_t QnCorrectionsQnVectorAlignment::CreateQAHistograms(TList *list) {
 Bool_t QnCorrectionsQnVectorAlignment::CreateNveQAHistograms(TList *list) {
 
   fQANotValidatedBin = new QnCorrectionsHistogramSparse(
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
       fDetectorConfiguration->GetEventClassVariablesSet());
   fQANotValidatedBin->CreateHistogram(list);
   return kTRUE;
@@ -227,9 +227,9 @@ Bool_t QnCorrectionsQnVectorAlignment::ProcessCorrections(const Float_t *variabl
     /* and proceed to ... */
   case QCORRSTEP_apply: /* apply the correction if the current Qn vector is good enough */
     /* logging */
-    QnCorrectionsInfo(Form("Alignment process in detector %s with reference %s: applying correction.",
+    QnCorrectionsInfo(TString::Format("Alignment process in detector %s with reference %s: applying correction.",
         fDetectorConfiguration->GetName(),
-        fDetectorConfigurationForAlignment->GetName()));
+        fDetectorConfigurationForAlignment->GetName()).Data());
     if (fDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) {
       /* we get the properties of the current Qn vector but its name */
       fCorrectedQnVector->Set(fDetectorConfiguration->GetCurrentQnVector(),kFALSE);
@@ -288,9 +288,9 @@ Bool_t QnCorrectionsQnVectorAlignment::ProcessDataCollection(const Float_t *vari
   switch (fState) {
   case QCORRSTEP_calibration:
     /* logging */
-    QnCorrectionsInfo(Form("Alignment process in detector %s with reference %s: collecting data.",
+    QnCorrectionsInfo(TString::Format("Alignment process in detector %s with reference %s: collecting data.",
         fDetectorConfiguration->GetName(),
-        fDetectorConfigurationForAlignment->GetName()));
+        fDetectorConfigurationForAlignment->GetName()).Data());
     /* collect the data needed to further produce correction parameters if both current Qn vectors are good enough */
     if ((fInputQnVector->IsGoodQuality()) &&
         (fDetectorConfigurationForAlignment->GetCurrentQnVector()->IsGoodQuality())) {
@@ -312,9 +312,9 @@ Bool_t QnCorrectionsQnVectorAlignment::ProcessDataCollection(const Float_t *vari
     break;
   case QCORRSTEP_applyCollect:
     /* logging */
-    QnCorrectionsInfo(Form("Alignment process in detector %s with reference %s: collecting data.",
+    QnCorrectionsInfo(TString::Format("Alignment process in detector %s with reference %s: collecting data.",
         fDetectorConfiguration->GetName(),
-        fDetectorConfigurationForAlignment->GetName()));
+        fDetectorConfigurationForAlignment->GetName()).Data());
     /* collect the data needed to further produce correction parameters if both current Qn vectors are good enough */
     if ((fInputQnVector->IsGoodQuality()) &&
         (fDetectorConfigurationForAlignment->GetCurrentQnVector()->IsGoodQuality())) {

--- a/QnCorrections/QnCorrectionsQnVectorRecentering.cxx
+++ b/QnCorrections/QnCorrectionsQnVectorRecentering.cxx
@@ -101,7 +101,7 @@ void QnCorrectionsQnVectorRecentering::CreateSupportDataStructures() {
 /// \return kTRUE if everything went OK
 Bool_t QnCorrectionsQnVectorRecentering::CreateSupportHistograms(TList *list) {
 
-  TString histoNameAndTitle = Form("%s %s ",
+  TString histoNameAndTitle = TString::Format("%s %s ",
       szSupportHistogramName,
       fDetectorConfiguration->GetName());
 
@@ -127,7 +127,7 @@ Bool_t QnCorrectionsQnVectorRecentering::CreateSupportHistograms(TList *list) {
 Bool_t QnCorrectionsQnVectorRecentering::AttachInput(TList *list) {
 
   if (fInputHistograms->AttachHistograms(list)) {
-    QnCorrectionsInfo(Form("Recentering on %s going to be applied", fDetectorConfiguration->GetName()));
+    QnCorrectionsInfo(TString::Format("Recentering on %s going to be applied", fDetectorConfiguration->GetName()).Data());
     fState = QCORRSTEP_applyCollect;
     return kTRUE;
   }
@@ -142,8 +142,8 @@ Bool_t QnCorrectionsQnVectorRecentering::AttachInput(TList *list) {
 Bool_t QnCorrectionsQnVectorRecentering::CreateQAHistograms(TList *list) {
 
   fQAQnAverageHistogram = new QnCorrectionsProfileComponents(
-      Form("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()),
-      Form("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()),
+      TString::Format("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
+      TString::Format("%s %s", szQAQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
       fDetectorConfiguration->GetEventClassVariablesSet());
 
   /* get information about the configured harmonics to pass it for histogram creation */
@@ -163,8 +163,8 @@ Bool_t QnCorrectionsQnVectorRecentering::CreateQAHistograms(TList *list) {
 Bool_t QnCorrectionsQnVectorRecentering::CreateNveQAHistograms(TList *list) {
 
   fQANotValidatedBin = new QnCorrectionsHistogramSparse(
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
-      Form("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
+      TString::Format("%s %s", szQANotValidatedHistogramName, fDetectorConfiguration->GetName()).Data(),
       fDetectorConfiguration->GetEventClassVariablesSet());
   fQANotValidatedBin->CreateHistogram(list);
   return kTRUE;
@@ -186,7 +186,7 @@ Bool_t QnCorrectionsQnVectorRecentering::ProcessCorrections(const Float_t *varia
     /* collect the data needed to further produce correction parameters if the current Qn vector is good enough */
     /* and proceed to ... */
   case QCORRSTEP_apply: /* apply the correction if the current Qn vector is good enough */
-    QnCorrectionsInfo(Form("Recentering process in detector %s: applying correction.", fDetectorConfiguration->GetName()));
+    QnCorrectionsInfo(TString::Format("Recentering process in detector %s: applying correction.", fDetectorConfiguration->GetName()).Data());
     if (fDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) {
       /* we get the properties of the current Qn vector but its name */
       fCorrectedQnVector->Set(fDetectorConfiguration->GetCurrentQnVector(),kFALSE);
@@ -239,7 +239,7 @@ Bool_t QnCorrectionsQnVectorRecentering::ProcessDataCollection(const Float_t *va
   Int_t harmonic;
   switch (fState) {
   case QCORRSTEP_calibration:
-    QnCorrectionsInfo(Form("Recentering process in detector %s: collecting data.", fDetectorConfiguration->GetName()));
+    QnCorrectionsInfo(TString::Format("Recentering process in detector %s: collecting data.", fDetectorConfiguration->GetName()).Data());
     /* collect the data needed to further produce correction parameters if the current Qn vector is good enough */
     if (fInputQnVector->IsGoodQuality()) {
       harmonic = fInputQnVector->GetFirstHarmonic();
@@ -253,7 +253,7 @@ Bool_t QnCorrectionsQnVectorRecentering::ProcessDataCollection(const Float_t *va
     return kFALSE;
     break;
   case QCORRSTEP_applyCollect:
-    QnCorrectionsInfo(Form("Recentering process in detector %s: collecting data.", fDetectorConfiguration->GetName()));
+    QnCorrectionsInfo(TString::Format("Recentering process in detector %s: collecting data.", fDetectorConfiguration->GetName()).Data());
     /* collect the data needed to further produce correction parameters if the current Qn vector is good enough */
     if (fInputQnVector->IsGoodQuality()) {
       harmonic = fInputQnVector->GetFirstHarmonic();

--- a/QnCorrections/QnCorrectionsQnVectorTwistAndRescale.cxx
+++ b/QnCorrections/QnCorrectionsQnVectorTwistAndRescale.cxx
@@ -109,9 +109,9 @@ QnCorrectionsQnVectorTwistAndRescale::~QnCorrectionsQnVectorTwistAndRescale() {
 /// \param nameB the name of the B detector configuration
 /// \param nameC the name of the C detector configuration
 void QnCorrectionsQnVectorTwistAndRescale::SetReferenceConfigurationsForTwistAndRescale(const char *nameB, const char *nameC) {
-  QnCorrectionsInfo(Form("Detector configurations: %s and %s, attached?: %s",
+  QnCorrectionsInfo(TString::Format("Detector configurations: %s and %s, attached?: %s",
       nameB, nameC,
-      ((fDetectorConfiguration != NULL) ? "yes" : "no")));
+      ((fDetectorConfiguration != NULL) ? "yes" : "no")).Data());
 
   fBDetectorConfigurationName = nameB;
   fCDetectorConfigurationName = nameC;
@@ -127,9 +127,9 @@ void QnCorrectionsQnVectorTwistAndRescale::AttachedToFrameworkManager() {
   case TWRESCALE_doubleHarmonic:
     break;
   case TWRESCALE_correlations:
-    QnCorrectionsInfo(Form("Attached! B and C detector configurations for twist and rescaling: %s and %s",
+    QnCorrectionsInfo(TString::Format("Attached! B and C detector configurations for twist and rescaling: %s and %s",
         fBDetectorConfigurationName.Data(),
-        fCDetectorConfigurationName.Data()));
+        fCDetectorConfigurationName.Data()).Data());
     break;
   default:
     QnCorrectionsFatal(Form("Wrong stored twist and rescale method: %d. FIX IT, PLEASE", fTwistAndRescaleMethod));
@@ -192,9 +192,9 @@ void QnCorrectionsQnVectorTwistAndRescale::CreateSupportDataStructures() {
       QnCorrectionsFatal(Form("Missing C detector configuration for %s twist and rescaling correction step",
           fDetectorConfiguration->GetName()));
     }
-    QnCorrectionsInfo(Form("Attached! B and C detector configurations for twist and rescaling: %s and %s",
+    QnCorrectionsInfo(TString::Format("Attached! B and C detector configurations for twist and rescaling: %s and %s",
         fBDetectorConfigurationName.Data(),
-        fCDetectorConfigurationName.Data()));
+        fCDetectorConfigurationName.Data()).Data());
     break;
   default:
     QnCorrectionsFatal(Form("Wrong stored twist and rescale method: %d. FIX IT, PLEASE", fTwistAndRescaleMethod));
@@ -212,11 +212,11 @@ void QnCorrectionsQnVectorTwistAndRescale::CreateSupportDataStructures() {
 /// \return kTRUE if everything went OK
 Bool_t QnCorrectionsQnVectorTwistAndRescale::CreateSupportHistograms(TList *list) {
 
-  TString histoDoubleHarmonicNameAndTitle = Form("%s %s ",
+  TString histoDoubleHarmonicNameAndTitle = TString::Format("%s %s ",
       szDoubleHarmonicSupportHistogramName,
       fDetectorConfiguration->GetName());
 
-  TString histoCorrelationsNameandTitle = Form("%s %s ",
+  TString histoCorrelationsNameandTitle = TString::Format("%s %s ",
       szCorrelationsSupportHistogramName,
       fDetectorConfiguration->GetName());
 
@@ -276,14 +276,14 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::AttachInput(TList *list) {
   case TWRESCALE_doubleHarmonic:
     /* TODO: basically we are re producing half of the information already produce for recentering correction. Re use it! */
     if (fDoubleHarmonicInputHistograms->AttachHistograms(list)) {
-      QnCorrectionsInfo(Form("Twist and rescale by the double harmonic method on %s going to be applied", fDetectorConfiguration->GetName()));
+      QnCorrectionsInfo(TString::Format("Twist and rescale by the double harmonic method on %s going to be applied", fDetectorConfiguration->GetName()).Data());
       fState = QCORRSTEP_applyCollect;
       return kTRUE;
     }
     break;
   case TWRESCALE_correlations:
     if (fCorrelationsInputHistograms->AttachHistograms(list)) {
-      QnCorrectionsInfo(Form("Twist and rescale by the correlations method on %s going to be applied", fDetectorConfiguration->GetName()));
+      QnCorrectionsInfo(TString::Format("Twist and rescale by the correlations method on %s going to be applied", fDetectorConfiguration->GetName()).Data());
       fState = QCORRSTEP_applyCollect;
       return kTRUE;
     }
@@ -311,8 +311,8 @@ void QnCorrectionsQnVectorTwistAndRescale::AfterInputsAttachActions() {
   case TWRESCALE_correlations:
     /* require B be applying twist corrections */
     if (!fBDetectorConfiguration->IsCorrectionStepBeingApplied(szTwistCorrectionName)) {
-      QnCorrectionsWarning(Form("Twist and rescale on %s requires %s be twist corrected which is not the case. CORRECTION STEP PASSIVE!!!",
-          fDetectorConfiguration->GetName(), fBDetectorConfiguration->GetName()));
+      QnCorrectionsWarning(TString::Format("Twist and rescale on %s requires %s be twist corrected which is not the case. CORRECTION STEP PASSIVE!!!",
+          fDetectorConfiguration->GetName(), fBDetectorConfiguration->GetName()).Data());
       fState = QCORRSTEP_passive;
     }
     break;
@@ -331,14 +331,14 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::CreateQAHistograms(TList *list) {
 
   if (fApplyTwist) {
     fQATwistQnAverageHistogram = new QnCorrectionsProfileComponents(
-        Form("%s %s", szQATwistQnAverageHistogramName, fDetectorConfiguration->GetName()),
-        Form("%s %s", szQATwistQnAverageHistogramName, fDetectorConfiguration->GetName()),
+        TString::Format("%s %s", szQATwistQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
+        TString::Format("%s %s", szQATwistQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
         fDetectorConfiguration->GetEventClassVariablesSet());
   }
   if (fApplyRescale) {
     fQARescaleQnAverageHistogram = new QnCorrectionsProfileComponents(
-        Form("%s %s", szQARescaleQnAverageHistogramName, fDetectorConfiguration->GetName()),
-        Form("%s %s", szQARescaleQnAverageHistogramName, fDetectorConfiguration->GetName()),
+        TString::Format("%s %s", szQARescaleQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
+        TString::Format("%s %s", szQARescaleQnAverageHistogramName, fDetectorConfiguration->GetName()).Data(),
         fDetectorConfiguration->GetEventClassVariablesSet());
   }
 
@@ -366,15 +366,15 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::CreateNveQAHistograms(TList *list) 
   switch (fTwistAndRescaleMethod) {
   case TWRESCALE_doubleHarmonic:
     fQANotValidatedBin = new QnCorrectionsHistogramSparse(
-        Form("%s%s %s", szQANotValidatedHistogramName, "DH", fDetectorConfiguration->GetName()),
-        Form("%s%s %s", szQANotValidatedHistogramName, "DH", fDetectorConfiguration->GetName()),
+        TString::Format("%s%s %s", szQANotValidatedHistogramName, "DH", fDetectorConfiguration->GetName()).Data(),
+        TString::Format("%s%s %s", szQANotValidatedHistogramName, "DH", fDetectorConfiguration->GetName()).Data(),
         fDetectorConfiguration->GetEventClassVariablesSet());
     fQANotValidatedBin->CreateHistogram(list);
     break;
   case TWRESCALE_correlations:
     fQANotValidatedBin = new QnCorrectionsHistogramSparse(
-        Form("%s%s %s", szQANotValidatedHistogramName, "CORR", fDetectorConfiguration->GetName()),
-        Form("%s%s %s", szQANotValidatedHistogramName, "CORR", fDetectorConfiguration->GetName()),
+        TString::Format("%s%s %s", szQANotValidatedHistogramName, "CORR", fDetectorConfiguration->GetName()).Data(),
+        TString::Format("%s%s %s", szQANotValidatedHistogramName, "CORR", fDetectorConfiguration->GetName()).Data(),
         fDetectorConfiguration->GetEventClassVariablesSet());
     fQANotValidatedBin->CreateHistogram(list);
     break;
@@ -406,8 +406,8 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessCorrections(const Float_t *v
     switch (fTwistAndRescaleMethod) {
     case TWRESCALE_doubleHarmonic: {
       /* TODO: basically we are re producing half of the information already produce for recentering correction. Re use it! */
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with double harmonic method.",
-          fDetectorConfiguration->GetName()));
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with double harmonic method.",
+          fDetectorConfiguration->GetName()).Data());
       if (fDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) {
         fCorrectedQnVector->Set(fDetectorConfiguration->GetCurrentQnVector(),kFALSE);
         fTwistCorrectedQnVector->Set(fCorrectedQnVector, kFALSE);
@@ -472,10 +472,10 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessCorrections(const Float_t *v
     break;
 
     case TWRESCALE_correlations: {
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with correlations with %s and %s method.",
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with correlations with %s and %s method.",
           fDetectorConfiguration->GetName(),
           fBDetectorConfiguration->GetName(),
-          fCDetectorConfiguration->GetName()));
+          fCDetectorConfiguration->GetName()).Data());
       if (fDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) {
         fCorrectedQnVector->Set(fDetectorConfiguration->GetCurrentQnVector(),kFALSE);
         fTwistCorrectedQnVector->Set(fCorrectedQnVector, kFALSE);
@@ -573,8 +573,8 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessDataCollection(const Float_t
     /* logging */
     switch (fTwistAndRescaleMethod) {
     case TWRESCALE_doubleHarmonic: {
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with double harmonic method. Collecting data",
-          fDetectorConfiguration->GetName()));
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with double harmonic method. Collecting data",
+          fDetectorConfiguration->GetName()).Data());
       /* remember, we store in the profiles the double harmonic while the Q2n vector stores them single */
       QnCorrectionsQnVector *plainQ2nVector = fDetectorConfiguration->GetPlainQ2nVector();
       Int_t harmonic = fCorrectedQnVector->GetFirstHarmonic();
@@ -589,10 +589,10 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessDataCollection(const Float_t
     break;
 
     case TWRESCALE_correlations: {
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with correlations with %s and %s method. Collecting data",
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with correlations with %s and %s method. Collecting data",
           fDetectorConfiguration->GetName(),
           fBDetectorConfiguration->GetName(),
-          fCDetectorConfiguration->GetName()));
+          fCDetectorConfiguration->GetName()).Data());
       /* collect the data needed to further produce correction parameters if both current Qn vectors are good enough */
       if ((fInputQnVector->IsGoodQuality()) &&
           (fBDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) &&
@@ -617,8 +617,8 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessDataCollection(const Float_t
     /* logging */
     switch (fTwistAndRescaleMethod) {
     case TWRESCALE_doubleHarmonic: {
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with double harmonic method. Collecting data",
-          fDetectorConfiguration->GetName()));
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with double harmonic method. Collecting data",
+          fDetectorConfiguration->GetName()).Data());
       /* remember, we store in the profiles the double harmonic while the Q2n vector stores them single */
       QnCorrectionsQnVector *plainQ2nVector = fDetectorConfiguration->GetPlainQ2nVector();
       Int_t harmonic = fCorrectedQnVector->GetFirstHarmonic();
@@ -633,10 +633,10 @@ Bool_t QnCorrectionsQnVectorTwistAndRescale::ProcessDataCollection(const Float_t
     break;
 
     case TWRESCALE_correlations: {
-      QnCorrectionsInfo(Form("Twist and rescale in detector %s with correlations with %s and %s method. Collecting data",
+      QnCorrectionsInfo(TString::Format("Twist and rescale in detector %s with correlations with %s and %s method. Collecting data",
           fDetectorConfiguration->GetName(),
           fBDetectorConfiguration->GetName(),
-          fCDetectorConfiguration->GetName()));
+          fCDetectorConfiguration->GetName()).Data());
       /* collect the data needed to further produce correction parameters if both current Qn vectors are good enough */
       if ((fInputQnVector->IsGoodQuality()) &&
           (fBDetectorConfiguration->GetCurrentQnVector()->IsGoodQuality()) &&


### PR DESCRIPTION
The behavior of "Form" in nested calls is unexpected, outer values are overwritten by the nested ones.